### PR TITLE
use IPv4zero by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 # 
 
 MODULE     := github.com/situation-sh/situation
-VERSION    := 0.13.7
+VERSION    := 0.13.8
 COMMIT     := $(shell git rev-parse HEAD)
 
 # system stuff

--- a/modules/docker/docker.go
+++ b/modules/docker/docker.go
@@ -185,9 +185,9 @@ func RunBasic(ctx context.Context, p *Platform, logger *logrus.Entry) error {
 		// loop over the containers
 		for containerID, endpoint := range network.Containers {
 			// fmt.Printf("\t - %v [%v] %s\n",
-			// endpoint.IPv4Address,
-			// endpoint.IPv6Address,
-			// endpoint.Name)
+			// 	endpoint.IPv4Address,
+			// 	endpoint.IPv6Address,
+			// 	endpoint.Name)
 			// container, err := m.getContainerByName(endpoint.Name)
 			container, err := getContainerByID(ctx, p.client, containerID)
 			// fmt.Printf(" ENDPOINT: %+v\n", endpoint)
@@ -235,22 +235,28 @@ func RunBasic(ctx context.Context, p *Platform, logger *logrus.Entry) error {
 			}
 
 			// add an endpoint for every exposed ports
+			// TODO: Here we have a problem with the IP -> it is the Host IP and
+			// not the container IP. One can set to 0.0.0.0 for the moment until
+			// we find a workaround (we can run netstat in the namespace but it
+			// won't work on windows)
 			for _, port := range container.Ports {
-				var ip net.IP
-				if port.IP == "" {
-					ip = net.IPv4zero
-				} else if port.IP == "::" {
-					ip = net.IPv6zero
-				} else {
-					ip = net.ParseIP(port.IP)
-				}
-				endpoint, created := app.AddEndpoint(ip, port.PrivatePort, port.Type)
+				// fmt.Println("IP:", port.IP)
+				// var ip net.IP
+				// if port.IP == "" {
+				// 	ip = net.IPv4zero
+				// } else if port.IP == "::" {
+				// 	ip = net.IPv6zero
+				// } else {
+				// 	ip = net.ParseIP(port.IP)
+				// }
+				ip := net.IPv4zero
+				ep, created := app.AddEndpoint(ip, port.PrivatePort, port.Type)
 				if created {
 					logger.
 						WithField("container", machine.Hostname).
-						WithField("ip", endpoint.Addr).
-						WithField("port", endpoint.Port).
-						WithField("proto", endpoint.Protocol).
+						WithField("ip", ep.Addr).
+						WithField("port", ep.Port).
+						WithField("proto", ep.Protocol).
 						Info("Application endpoint found")
 				}
 			}


### PR DESCRIPTION
Before fixing #27, we prefer set the default listening address to `0.0.0.0` (this is quite a common config in the docker ecosystem)